### PR TITLE
Updated Tags APIDoc

### DIFF
--- a/website/server/controllers/api-v3/tags.js
+++ b/website/server/controllers/api-v3/tags.js
@@ -152,10 +152,16 @@ api.updateTag = {
  * @apiName ReorderTags
  * @apiGroup Tag
  *
- * @apiParam {UUID} tagId Id of the tag to move
- * @apiParam {Number} to Position the tag is moving to
+ * @apiParam (body) {UUID} tagId Id of the tag to move
+ * @apiParam (body) {Number} to Position the tag is moving to
+ *
+ * @apiParamExample {json} Example request:
+ * {"tagId":"c6855fae-ca15-48af-a88b-86d0c65ead47","to":0}
  *
  * @apiSuccess {Object} data An empty object
+ *
+ * @apiSuccessExample {json} Example return:
+ * {"success":true,"data":{},"notifications":[]}
  *
  * @apiUse TagNotFound
  */

--- a/website/server/controllers/api-v3/tags.js
+++ b/website/server/controllers/api-v3/tags.js
@@ -12,6 +12,12 @@ import { removeFromArray } from '../../libs/collectionManipulators';
  * @apiError (404) {NotFound} TagNotFound The specified tag could not be found.
  */
 
+/**
+ * @apiDefine InvalidUUID
+ * @apiError (400) {BadRequest} InvalidRequestParameters "tagId" must be a valid UUID corresponding to a tag belonging to the user.
+ */
+
+
 let api = {};
 
 /**
@@ -78,6 +84,7 @@ api.getTags = {
  * {"success":true,"data":{"name":"practicetag","id":"8bc0afbf-ab8e-49a4-982d-67a40557ed1a"},"notifications":[]}
  *
  * @apiUse TagNotFound
+ * @apiUSe InvalidUUID
  */
 api.getTag = {
   method: 'GET',
@@ -114,6 +121,7 @@ api.getTag = {
  * {"success":true,"data":{"name":"practice-tag","id":"8bc0afbf-ab8e-49a4-982d-67a40557ed1a"},"notifications":[]}
  *
  * @apiUse TagNotFound
+ * @apiUSe InvalidUUID
  */
 api.updateTag = {
   method: 'PUT',
@@ -188,6 +196,7 @@ api.reorderTags = {
  * {"success":true,"data":{},"notifications":[]}
  *
  * @apiUse TagNotFound
+ * @apiUSe InvalidUUID
  */
 api.deleteTag = {
   method: 'DELETE',


### PR DESCRIPTION
All commands updated except "reorder-tags"

https://github.com/HabitRPG/habitica/issues/8087

Unable to get a working example of reorder-tags.
I have tried the following posts:
URL: https://habitica.com/api/v3/reorder-tags/1c32acb0-09a2-4e92-b7db-4c99b0824328
BODY: {"to":0}
RESULT: {"success":false,"error":"NotFound","message":"Not found."}

URL:  https://habitica.com/api/v3/reorder-tags
BODY:  {"tagID":"1c32acb0-09a2-4e92-b7db-4c99b0824328","to":0}
RESULT:  {"success":false,"error":"BadRequest","message":"Invalid request parameters.","errors":[{"message":"\"tagId\" must be a valid UUID corresponding to a tag belonging to the user.","param":"tagId"}]}

what am I missing?
----
UUID: b0413351-405f-416f-8787-947ec1c85199